### PR TITLE
fix(astro): remove raw CSS injection in astro:build:done (prod styling loss + Windows crash)

### DIFF
--- a/Packages/integrations/view/astro/src/index.ts
+++ b/Packages/integrations/view/astro/src/index.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
 import { viewPlugin } from "@hedystia/view/vite";
 import type { AstroIntegration, AstroRenderer } from "astro";
 import type { Plugin, UserConfig } from "vite";
@@ -20,7 +18,7 @@ export interface Options {
 }
 
 export default function (options: Options = {}): AstroIntegration {
-  const { plugins, collectedCSS } = viewPlugin(options);
+  const { plugins } = viewPlugin(options);
 
   return {
     name: "@hedystia/astro",
@@ -36,47 +34,8 @@ export default function (options: Options = {}): AstroIntegration {
           },
         });
       },
-      "astro:build:done": async ({ dir }) => {
-        if (collectedCSS.size > 0) {
-          const css = Array.from(collectedCSS.values()).join("\n");
-          injectCSSIntoHTML(dir.pathname, css);
-        }
-      },
     },
   };
-}
-
-function injectCSSIntoHTML(dir: string, css: string): void {
-  const styleTag = `<style data-hedystia-css>${css}</style>`;
-
-  for (const file of findHTMLFiles(dir)) {
-    let content = fs.readFileSync(file, "utf-8");
-    if (content.includes("data-hedystia-css")) {
-      continue;
-    }
-    if (content.includes("</head>")) {
-      content = content.replace("</head>", `${styleTag}</head>`);
-    } else {
-      content = `${styleTag}${content}`;
-    }
-    fs.writeFileSync(file, content, "utf-8");
-  }
-}
-
-function findHTMLFiles(dir: string): string[] {
-  const files: string[] = [];
-  const walk = (d: string) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.name.endsWith(".html")) {
-        files.push(full);
-      }
-    }
-  };
-  walk(dir);
-  return files;
 }
 
 function configEnvironmentPlugin(): Plugin {

--- a/Packages/view/src/vite.ts
+++ b/Packages/view/src/vite.ts
@@ -1,7 +1,5 @@
 import type { Plugin, UserConfig } from "vite";
 
-const CSS_RE = /\.css$/;
-
 export interface ViewPluginOptions {
   include?: string[];
   exclude?: string[];
@@ -9,13 +7,19 @@ export interface ViewPluginOptions {
 
 export interface ViewPluginResult {
   plugins: Plugin[];
+  /**
+   * @deprecated Kept for backwards compatibility. CSS imported by View
+   * components is emitted by the host bundler (Vite/Astro) through the normal
+   * module graph, so manual collection is no longer needed and this map is
+   * always empty.
+   */
   collectedCSS: Map<string, string>;
 }
 
 export function viewPlugin(options: ViewPluginOptions = {}): ViewPluginResult {
   const collectedCSS = new Map<string, string>();
 
-  const plugins: Plugin[] = [viewJSXPlugin(options), viewCSSCollectorPlugin(collectedCSS)];
+  const plugins: Plugin[] = [viewJSXPlugin(options)];
 
   return { plugins, collectedCSS };
 }
@@ -30,19 +34,6 @@ function viewJSXPlugin(_options: ViewPluginOptions): Plugin {
           jsxImportSource: "@hedystia/view",
         },
       };
-    },
-  };
-}
-
-function viewCSSCollectorPlugin(collectedCSS: Map<string, string>): Plugin {
-  return {
-    name: "@hedystia/view:css-collector",
-    enforce: "pre",
-    transform(code, id) {
-      if (!CSS_RE.test(id)) {
-        return;
-      }
-      collectedCSS.set(id.replace(/\\/g, "/"), code);
     },
   };
 }


### PR DESCRIPTION
## Problem

When building an Astro + Tailwind site that uses `@hedystia/view` components, several UI elements lose their styling (or visually disappear) in the **production build**, while `astro dev` renders everything correctly. Affected: navbar buttons, hero/features/pricing/team sections, scoped colors (notably `black` button variants), etc.

## Root cause

The integration registered a `viewCSSCollectorPlugin` (a `enforce: "pre"` Vite `transform` over **every** `.css` id) and, in the `astro:build:done` hook, injected all of that collected CSS â€” raw and unscoped â€” into **every** generated HTML page via `injectCSSIntoHTML`.

This caused, in production only (the hook doesn't run in dev):

- **Cross-page contamination & bloat**: the raw CSS of *all* view `style.css` files (including unrelated pages such as admin) was dumped into *every* page. On a real site this inflated the homepage HTML from ~196 KB to ~535 KB (~337 KB of duplicated, unscoped CSS).
- **Cascade inversion**: the block was appended after the real, compiled stylesheet, so unlayered raw rules overrode Tailwind's layered utilities.
- **Invalid rules silently dropped**: pre-processor-only syntax that reached the browser (e.g. `:global(...)`) was discarded, breaking scoped component styles such as dark-mode button colors.
- **Windows build crash**: `injectCSSIntoHTML` used `dir.pathname` directly as a filesystem path, yielding `/C:/â€¦%20â€¦` (leading slash + un-decoded spaces) â†’ `ENOENT` and a failed build.

The collector was also **redundant**: Astro already emits and links the CSS imported by View components through the normal Vite module graph (verified â€” component `style.css` is inlined/linked per page without any injection).

## Fix

- Remove `viewCSSCollectorPlugin` from `viewPlugin` (keep only the JSX plugin).
- Remove the `astro:build:done` hook and the `injectCSSIntoHTML` / `findHTMLFiles` helpers from the Astro integration.
- `ViewPluginResult.collectedCSS` is kept (now always empty) and marked `@deprecated` to preserve the public API shape.

Production output now matches dev with **no changes required on the consumer side**, and the per-page CSS is smaller (no duplication).

## Verification

- `@hedystia/view` and `@hedystia/astro` rebuilt with `tsdown`.
- Full relevant test suite green: **122 tests / 16 files** (`view` + `integrations/view/astro`).
- `biome check` clean on both changed files.
- Validated against a real Astro 5 + Tailwind v4 site: homepage back to 196 KB, no cross-page contamination, scoped navbar styles and Tailwind utilities intact, View component CSS still emitted/linked by Astro, build no longer crashes on Windows.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Astro build behavior by removing automatic CSS injection during site generation, making output more predictable.
  * Deprecated CSS collection now remains empty for backward compatibility, avoiding unexpected build-side effects.
* **Refactor**
  * Simplified the integration setup and plugin pipeline to rely on a leaner rendering flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->